### PR TITLE
Bump HDSentinel from 5.61 to 5.70

### DIFF
--- a/dist/hdsentinel/hdsentinel.nuspec
+++ b/dist/hdsentinel/hdsentinel.nuspec
@@ -4,7 +4,7 @@
     <metadata>
         <id>hdsentinel</id>
         <title>Hard Disk Sentinel</title>
-        <version>5.61</version>
+        <version>5.70</version>
         <authors>H.D.S. Hungary.</authors>
         <owners>criography</owners>
         <summary>Hard Disk Sentinel is an application designed to monitor HDD activity and track the disk temperature.</summary>

--- a/dist/hdsentinel/tools/chocolateyInstall.ps1
+++ b/dist/hdsentinel/tools/chocolateyInstall.ps1
@@ -5,10 +5,10 @@ $ErrorActionPreference = 'Stop'; # stop on all errors
 $packageName    = "hdsentinel"
 $packageTitle   = "HDSentinel"
 $installerType  = "EXE"
-$packageVersion = "5.61"
+$packageVersion = "5.70"
 $url            = "http://www.harddisksentinel.com/hdsentinel_setup.zip"
 $silentArgs     = "/sp- /verysilent /norestart"
-$checksum       = "fdc87d2ea1c6e3d91db7d9dd22e76f51decf007a5c4f17ead93c6c4b772d825b"
+$checksum       = "1065e2aa48d0f681fb223615ea773ec1149abaa9ab9f4ccec9897f16237c3852"
 $checksumType   = "sha256"
 $validExitCodes = @(0)
 


### PR DESCRIPTION
Hi criography,

HDSentinel 5.70 has been released.
The only change for installation are version number and checksum, so I only check the installation file can be done with silentArgs.

Looks like the files I modified are the compiled file, so feel free to close this PR if it's not do in the right way for you.